### PR TITLE
examples: fix minor typo

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -224,9 +224,9 @@ using App2Interface =
         comms::option::MsgType<MsgId>, // Provide type used for message ID
         comms::option::IdInfoInterface, // Support polymorphic retreival of message ID
         comms::option::ReadIterator<const std::uint8_t*>, // Support polymorphic read using "const std::uint8_t*" as iterator
-        comms::option::WriteIterator<std::back_insert_itetrator<std::vector<std::uint8_t> > >, 
+        comms::option::WriteIterator<std::back_insert_iterator<std::vector<std::uint8_t> > >, 
                                                           // Support polymorphic write using
-                                                          // "std::back_insert_itetrator<std::vector<std::uint8_t> > >" as iterator
+                                                          // "std::back_insert_iterator<std::vector<std::uint8_t> > >" as iterator
         comms::option::Handler<MyOtherHandler> // Support dispatch to handling object of "MyOtherHandler" type
     >;
 ```


### PR DESCRIPTION
As per subject.

Happen to notice it while reading the example doc.
